### PR TITLE
:lipstick:style: scroll 제거 스타일 추가 #6

### DIFF
--- a/src/components/Feed/FeedHome/FeedHome.jsx
+++ b/src/components/Feed/FeedHome/FeedHome.jsx
@@ -20,7 +20,6 @@ export default function FeedHome() {
   const [myFeed, setMyFeed] = useState([]);
   const [page, setPage] = useState(0);
   const observer = useRef();
-
   const token = localStorage.getItem('token');
 
   const getFeed = async (options) => {
@@ -30,14 +29,14 @@ export default function FeedHome() {
   };
 
   const loadFeed = async (options) => {
-    let posts = await getFeed(options);
+    let Feeds = await getFeed(options);
     setMyFeed((prev) => {
       const prevId = prev.map((v) => v.id);
-      const postsId = posts.map((v) => v.id).filter((v) => !prevId.includes(v));
-      posts = posts.filter((v) => postsId.includes(v.id));
-      return [...prev, ...posts];
+      const FeedsId = Feeds.map((v) => v.id).filter((v) => !prevId.includes(v));
+      Feeds = Feeds.filter((v) => FeedsId.includes(v.id));
+      return [...prev, ...Feeds];
     });
-    setSkip((prev) => prev + posts.length);
+    setSkip((prev) => prev + Feeds.length);
     setLoading(false);
   };
   useEffect(() => {

--- a/src/components/style/GlobalStyle.jsx
+++ b/src/components/style/GlobalStyle.jsx
@@ -30,6 +30,11 @@ export const GlobalStyle = createGlobalStyle`
 
   :root {
     font-family: 'SpoqaHanSansNeo-Regular', sans-serif;
+    -ms-overflow-style: none; /* IE scroll disable*/
+    scrollbar-width: none;  /* 파이어폭스 scroll disable*/
+    ::-webkit-scrollbar {
+      display: none; /* 크롬, 사파리, 오페라, 엣지 scroll disable*/
+    }
   }
 
   li{


### PR DESCRIPTION
## 💡 관련 이슈
- #6 
<!-- - #이슈번호 -->

## ✍️ PR 한 줄 요약
- 웹 페이지 scroll 제거 Global 스타일 추가

## ✏ 상세 작업 내용
- 다수의 feed로 인해 생긴 scroll 디자인 요소 제거
  - scroll 기능은 유지하되, 오른쪽 scroll bar 제거
- 모든 페이지에서 scroll이 보이지 않도록 GrobalStyle로 설정
  - IE, 크롬, 사파리, 오페라, 엣지, 파이어폭스 웹 브라우저 적용
```javascript
  :root {
    font-family: 'SpoqaHanSansNeo-Regular', sans-serif;
    -ms-overflow-style: none; /* IE scroll disable*/
    scrollbar-width: none;  /* 파이어폭스 scroll disable*/
    ::-webkit-scrollbar {
      display: none; /* 크롬, 사파리, 오페라, 엣지 scroll disable*/
    }
  }
``` 
![image](https://github.com/FRONTENDSCHOOL7/final-12-HoloNyamNyam/assets/11751089/56a27dd1-9812-48ab-b5dd-9031f0fa2ad0)

## ⭐ 참고 사항

## ✅ PR 양식 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. ✨feat: PR 등록
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
