### PR TITLE
:bug:fix: Feed 댓글관련 접근성 개선 #37

### DIFF
--- a/src/components/Feed/FeedComment/FeedComment.jsx
+++ b/src/components/Feed/FeedComment/FeedComment.jsx
@@ -61,7 +61,7 @@ export default function DetailFeed() {
       const res = await commentUploadApi(id, inputValue, token);
       setInputValue('');
       loadCommentList();
-      setCommentList((prev) => [...prev, res.data.comment]);
+      setCommentList((prev) => [res.data.comment, ...prev]);
       setComment(res.data.comment);
       setCommentCnt((prev) => prev + 1);
       setInputValue('');
@@ -175,6 +175,7 @@ export default function DetailFeed() {
             getUserInfo={fetchFeedInfo}
             setCommentCnt={setCommentCnt}
             commentCnt={commentCnt}
+            detail={true}
           />
         </FeedItemSection>
         <CommentSection>

--- a/src/components/Feed/FeedHome/FeedHome.jsx
+++ b/src/components/Feed/FeedHome/FeedHome.jsx
@@ -104,6 +104,7 @@ export default function FeedHome() {
                   }
                   feedInfo={where === item.author.accountname ? item : false}
                   otherInfo={where === item.author.accountname ? false : item}
+                  commentCnt={item.commentCount}
                   // getFeed={getFeed}
                   // skip={skip}
                 />

--- a/src/components/Feed/FeedItem/FeedItem.jsx
+++ b/src/components/Feed/FeedItem/FeedItem.jsx
@@ -27,6 +27,7 @@ export default function FeedItem({
   otherInfo,
   getUserInfo,
   commentCnt,
+  detail,
 }) {
   const SocialSVG = ({
     id,
@@ -132,15 +133,15 @@ export default function FeedItem({
           </MoreBtn>
         </FeedUser>
       )}
-      <FeedContent>
+      <FeedContent
+        onClick={detail === true ? null : () => moveDetail(infoToIterate.id)}
+        style={{ cursor: detail === true ? 'default' : 'pointer' }}
+      >
         <FeedText>{infoToIterate.content}</FeedText>
         {infoToIterate.image && infoToIterate.author && (
           <Carousel
             images={infoToIterate.image}
             userInfo={infoToIterate.author.username}
-            onImageClick={() => {
-              moveDetail(infoToIterate.id);
-            }}
           />
         )}
         <FeedInfoBox>

--- a/src/components/Feed/FeedItem/StyledFeedItem.jsx
+++ b/src/components/Feed/FeedItem/StyledFeedItem.jsx
@@ -14,8 +14,8 @@ const FeedUserImg = styled.img`
   width: 42px;
   height: 42px;
   border-radius: 50%;
-  cursor: pointer;
   object-fit: cover;
+  cursor: pointer;
 `;
 const FeedUserBox = styled.div`
   align-self: center;
@@ -35,6 +35,7 @@ const FeedContent = styled.div`
   font-size: 14px;
   line-height: 17px;
   word-break: break-all;
+  cursor: pointer;
 `;
 const FeedText = styled.p`
   margin-bottom: 17px;


### PR DESCRIPTION
## 💡 관련 이슈
- #37 
<!-- - #이슈번호 -->

## ✍️ PR 한 줄 요약
Feed 댓글관련 버그 접근성 개선

## ✏ 상세 작업 내용
- Home 페이지에서 Feed 댓글 개수가 안보이는 버그 해결
- Feed 이미지뿐만 아니라 Text를 포한한 FeedContent에서 마우스 커서를 Pointer로 변경
- FeedContent에서 마우스를 클릭하면 DetailFeed 페이지로 이동하고, DetailFeed에서는 Click Event 제거
- Feed Comment 추가 시 쌓이는 위치를 제일 아래에서, 제일 위로 변경
![image](https://github.com/FRONTENDSCHOOL7/final-12-HoloNyamNyam/assets/11751089/54fadefe-d4c4-431a-9064-21f38f5bd49f)

## ⭐ 참고 사항
- 댓글 수정 기능은 추가 기능(필수x)으로 함

## ✅ PR 양식 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. ✨feat: PR 등록
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
