### PR TITLE
:recycle:refactor: 냠냠평가  삭제 코드 수정

### DIFF
--- a/src/components/Modal/Alert/Alert.jsx
+++ b/src/components/Modal/Alert/Alert.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import {
   AlertDiv,
   AlertWrapArticle,
@@ -25,6 +25,7 @@ export default function Alert({
   handleCommentDelete,
 }) {
   const navigate = useNavigate();
+  const location = useLocation();
   const [modal, setModal] = useRecoilState(modalState);
   // eslint-disable-next-line no-unused-vars
   const [cardShow, setCardShow] = useRecoilState(cardShowState);
@@ -60,7 +61,12 @@ export default function Alert({
       await recommendDeleteApi(productId, token);
       alertClose('place');
       modalClose('myPlace');
-      navigate('/myprofile');
+      if (location.pathname === '/placelist') {
+        navigate('/placelist');
+      } else {
+        navigate('/myprofile');
+      }
+
       setCardShow(false);
     } catch (error) {
       console.error('Delete request failed', error);

--- a/src/pages/Place/PlaceList.jsx
+++ b/src/pages/Place/PlaceList.jsx
@@ -5,6 +5,8 @@ import PlaceListItem from '../../components/Place/PlaceListItem';
 import Nav from '../../components/common/Nav/Nav';
 import styled from 'styled-components';
 import PlaceCard from '../../components/Modal/PlaceCard/PlaceCard';
+import { useRecoilState } from 'recoil';
+import { cardShowState } from '../../recoil/cardShowAtom';
 
 const List = styled.section`
   padding: 48px 0 60px 0;
@@ -23,7 +25,7 @@ export default function PlaceList() {
   const [selectedId, setSelectedId] = useState(null);
   const [cardClosed, setCardClosed] = useState(false);
 
-  const [cardShow, setCardShow] = useState(false);
+  const [cardShow, setCardShow] = useRecoilState(cardShowState);
   function cardClose(e) {
     if (e.target === e.currentTarget) {
       setCardShow(false);
@@ -46,7 +48,9 @@ export default function PlaceList() {
       <List>
         <PlaceWrap>
           <PlaceListItem cardOpen={cardOpen} cardClosed={cardClosed} />
-          {cardShow && <PlaceCard cardClose={cardClose} id={selectedId} />}
+          {cardShow && selectedId && (
+            <PlaceCard cardClose={cardClose} id={selectedId} />
+          )}
         </PlaceWrap>
       </List>
       <Nav />


### PR DESCRIPTION
## 💡 관련 이슈

- #50

## ✍️ PR 한 줄 요약

삭제버튼 경로 수정

## ✏ 상세 작업 내용

기존 냠냠평가 삭제 버튼 클릭 시 profile 링크로 이동하는 것을 발견
-> 삭제해도 냠냠평가 더보기 링크에 머물도록 코드 수정

## ⭐ 참고 사항

## ✅ PR 양식 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. ✨feat: PR 등록
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
