### PR TITLE
:lipstick:style: 모달 CSS 및 네비 아이콘 수정

### DIFF
--- a/src/components/Feed/FeedCreate/StyledFeedCreate.jsx
+++ b/src/components/Feed/FeedCreate/StyledFeedCreate.jsx
@@ -3,7 +3,8 @@ import sprite from '../../../images/SpriteIcon.svg';
 
 const StyledContainer = styled.section`
   width: 100%;
-  height: calc(100vh - 48px);
+  /* height: calc(100vh - 48px); */
+  height: 100vh;
   padding-top: 48px;
   overflow: hidden;
   background: #fff;

--- a/src/components/Feed/FeedList/FeedList.jsx
+++ b/src/components/Feed/FeedList/FeedList.jsx
@@ -47,6 +47,7 @@ export default function FeedList() {
   const [page, setPage] = useState(0);
   const limit = 10;
   const [loading, setLoading] = useState(true);
+  const where = localStorage.getItem('accountname');
 
   const { accountname } = location.state || {};
   const handleViewModeChange = (mode) => {
@@ -85,7 +86,7 @@ export default function FeedList() {
   }, []);
 
   function moveDetail(item) {
-    navigate(`/detailfeed`, {
+    navigate(`/feeddetail`, {
       state: {
         id: item.id,
         infoToIterate: item,
@@ -168,7 +169,12 @@ export default function FeedList() {
                 <FeedListItem key={item.id}>
                   <FeedItem
                     modalOpen={() =>
-                      modalOpen(!accountname ? 'myFeed' : 'yourFeed', item)
+                      modalOpen(
+                        where === item.author.accountname
+                          ? 'myFeed'
+                          : 'yourFeed',
+                        item,
+                      )
                     }
                     feedInfo={item}
                     getUserInfo={getUserInfo}

--- a/src/components/Modal/Modal/Modal.jsx
+++ b/src/components/Modal/Modal/Modal.jsx
@@ -114,11 +114,7 @@ export default function Modal({
     myProfile: (
       <ModalWrapArticle>
         <ModalLineSpan />
-        {detail || (
-          <ModalTextBtn onClick={handlerMyProfile}>
-            설정 및 개인정보
-          </ModalTextBtn>
-        )}
+        <ModalTextBtn onClick={handlerMyProfile}>설정 및 개인정보</ModalTextBtn>
         <ModalTextBtn onClick={() => alertOpen('logout')}>
           로그아웃
         </ModalTextBtn>
@@ -185,7 +181,7 @@ export default function Modal({
       </ModalWrapArticle>
     ),
     chat: (
-      <ModalWrapArticle>
+      <ModalWrapArticle style={{ borderBottom: '1px solid #dbdbdb' }}>
         <ModalLineSpan />
         <ModalTextBtn onClick={() => alertOpen('reportUser')}>
           신고하기

--- a/src/components/Modal/Modal/ModalStyle.jsx
+++ b/src/components/Modal/Modal/ModalStyle.jsx
@@ -9,6 +9,8 @@ const ModalDim = styled.div`
   background-color: rgba(0, 0, 0, 0.3);
   width: 100%;
   max-width: 390px;
+  box-sizing: border-box;
+  z-index: 101;
 `;
 
 const slideUp = keyframes`
@@ -26,7 +28,7 @@ const ModalWrapArticle = styled.article`
   background-color: white;
   box-sizing: border-box;
   position: absolute;
-  bottom: 0;
+  bottom: 0px;
   width: 100%;
   animation: ${slideUp} 0.5s ease;
 `;

--- a/src/components/common/Header/Header.jsx
+++ b/src/components/common/Header/Header.jsx
@@ -31,6 +31,7 @@ export default function Header({
   handleUpdateProfileBtn,
   yourAccountname,
   name,
+  own,
 }) {
   const SocialSVG = ({
     id,
@@ -110,7 +111,7 @@ export default function Header({
     profile: (
       <HeaderLayoutSection>
         <HeaderTitle className='a11y-hidden'>프로필</HeaderTitle>
-        {renderHeaderLeftBtn()}
+        {own === 'my' ? renderHeaderText('나의 프로필') : renderHeaderLeftBtn()}
         {renderHeaderRightBtn()}
       </HeaderLayoutSection>
     ),
@@ -145,7 +146,7 @@ export default function Header({
     editprofile: (
       <HeaderLayoutSection>
         <HeaderTitle className='a11y-hidden'>프로필 수정</HeaderTitle>
-        {renderHeaderText("프로필 수정")}
+        {renderHeaderText('프로필 수정')}
         <Button
           type='button'
           content='저장'
@@ -153,7 +154,7 @@ export default function Header({
           width='ms'
           $bgcolor={handleUpdateProfileBtn ? 'active' : 'inactive'}
           disabled={!handleUpdateProfileBtn}
-          onClick = {uploadHandler}
+          onClick={uploadHandler}
         />
       </HeaderLayoutSection>
     ),

--- a/src/components/common/Nav/ChatNavStyle.jsx
+++ b/src/components/common/Nav/ChatNavStyle.jsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 const ChatNavBar = styled.nav`
   position: fixed;
-  max-width: 356px;
+  max-width: 390px;
   margin: 0 auto;
   left: 0;
   right: 0;
@@ -12,6 +12,7 @@ const ChatNavBar = styled.nav`
   align-items: center;
   padding: 13px 16px;
   background-color: white;
+  box-sizing: border-box;
 `;
 
 const ImageIcon = styled.img`

--- a/src/components/common/Nav/Nav.jsx
+++ b/src/components/common/Nav/Nav.jsx
@@ -86,7 +86,13 @@ export default function Nav() {
         </li>
         <li>
           <NavLink to='/feedupload'>
-            <NavSVG id='icon-edit' />
+            <NavSVG
+              id={
+                location.pathname === '/feedupload'
+                  ? 'icon-edit-fill'
+                  : 'icon-edit'
+              }
+            />
             <StyledNavText>게시물 작성</StyledNavText>
           </NavLink>
         </li>

--- a/src/components/common/Nav/StyledNav.jsx
+++ b/src/components/common/Nav/StyledNav.jsx
@@ -11,6 +11,7 @@ const NavWrapper = styled.nav`
   bottom: 0;
   background-color: #ffffff;
   border-top: 1px solid #dbdbdb;
+  box-shadow: 0px 3px 7px #c4c4c4;
 `;
 
 const NavList = styled.ul`

--- a/src/components/style/GlobalStyle.jsx
+++ b/src/components/style/GlobalStyle.jsx
@@ -76,6 +76,7 @@ export const GlobalStyle = createGlobalStyle`
     min-height: 100vh;
     margin: 0 auto;
     background-color: #fff;
+    box-shadow: 0px 0px 7px #c4c4c4;
   }
 `;
 

--- a/src/images/SpriteIcon.svg
+++ b/src/images/SpriteIcon.svg
@@ -13,6 +13,10 @@
         <rect width="18" height="18" x="3" y="3" stroke="#767676" stroke-width="2" rx="3" />
         <path stroke="#767676" stroke-linecap="round" stroke-width="2" d="M12 8v8m-4-4h8" />
     </symbol>
+    <symbol id="icon-edit-fill" viewBox="0 0 24 24">
+        <rect width="18" height="18" x="3" y="3" stroke="#FF644B" stroke-width="2" rx="3" fill="#FF644B" />
+        <path stroke="#FFFFFF" stroke-linecap="round" stroke-width="2" d="M12 8v8m-4-4h8" />
+    </symbol>
     <symbol id="icon-user" viewBox="0 0 24 24">
         <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 22v-3a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v3" />
         <path stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 22h16" />

--- a/src/images/navigationIcon.svg
+++ b/src/images/navigationIcon.svg
@@ -13,6 +13,10 @@
         <rect width="18" height="18" x="3" y="3" stroke="#767676" stroke-width="2" rx="3" />
         <path stroke="#767676" stroke-linecap="round" stroke-width="2" d="M12 8v8m-4-4h8" />
     </symbol>
+    <symbol id="icon-edit-fill" viewBox="0 0 24 24">
+        <rect width="18" height="18" x="3" y="3" stroke="#FF644B" stroke-width="2" rx="3" fill="#FF644B" />
+        <path stroke="#FFFFFF" stroke-linecap="round" stroke-width="2" d="M12 8v8m-4-4h8" />
+    </symbol>
     <symbol id="icon-user" viewBox="0 0 24 24">
         <path stroke="#767676" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 22v-3a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v3" />
         <path stroke="#767676" stroke-linecap="round" stroke-width="2" d="M4 22h16" />

--- a/src/pages/Feed/FeedUpload.jsx
+++ b/src/pages/Feed/FeedUpload.jsx
@@ -1,4 +1,10 @@
 import FeedCreate from '../../components/Feed/FeedCreate/FeedCreate';
+import Nav from '../../components/common/Nav/Nav';
 export default function FeedUpload() {
-  return <FeedCreate />;
+  return (
+    <>
+      <FeedCreate />
+      <Nav />
+    </>
+  );
 }

--- a/src/pages/Profile/Profile.jsx
+++ b/src/pages/Profile/Profile.jsx
@@ -7,10 +7,17 @@ import RatePlace from '../../components/Profile/RatePlace';
 import PlaceCard from '../../components/Modal/PlaceCard/PlaceCard';
 import { useRecoilState } from 'recoil';
 import { cardShowState } from '../../recoil/cardShowAtom';
+import { modalState } from '../../recoil/modalAtom';
+import { Navigate } from 'react-router-dom';
+import Modal from '../../components/Modal/Modal/Modal';
 
 export default function Profile({ type }) {
   const [selectedId, setSelectedId] = useState(null);
   const [cardClosed, setCardClosed] = useState(false);
+  // eslint-disable-next-line no-unused-vars
+  const [modal, setModal] = useRecoilState(modalState);
+  const accountname = localStorage.getItem('accountname');
+  window.console.log(modal);
 
   const [cardShow, setCardShow] = useRecoilState(cardShowState);
   function cardClose(e) {
@@ -30,14 +37,24 @@ export default function Profile({ type }) {
     }
   }, [cardClosed]);
 
+  const moveProfileEdit = (accountname) => {
+    Navigate(`/profile/${accountname}`);
+  };
+
   return (
     <>
-      <Header type='profile' />
+      <Header type='profile' own={type} />
       <InfoProfile type={type} />
       <RatePlace cardOpen={cardOpen} cardClosed={cardClosed} />
       <FeedList />
       {cardShow && selectedId && (
         <PlaceCard cardClose={cardClose} id={selectedId} />
+      )}
+      {modal.show && (
+        <Modal
+          type={modal.type}
+          handlerMyProfile={() => moveProfileEdit(accountname)}
+        />
       )}
       <Nav />
     </>


### PR DESCRIPTION
## 💡 관련 이슈
 - #31
 - #70

<!-- - #이슈번호 -->

## ✍️ PR 한 줄 요약
모달 CSS 및 네비 아이콘 수정
![image](https://github.com/FRONTENDSCHOOL7/final-12-HoloNyamNyam/assets/11751089/334dd3bd-1f8a-40a2-ba19-cd992de75aca)


## ✏ 상세 작업 내용
- [x] 모달이 네비게이션 뒤 위치해 가리는 z-index 문제 해결
- [x] FeedUpload 페이지에 확대시 스크롤 안되는 문제 해결
- [x] Profile 페이지에서 Header에 '나의 프로필' 추가
- [x] 채팅 모달에 Border bottom 추가
- [x] FeedUpload 페이지에 Nav 추가하고 아이콘 색 변경 추가
- [x] root에 테두리 그림자 추가

## ⭐ 참고 사항

## ✅ PR 양식 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. ✨feat: PR 등록
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
