### PR TITLE
:sparkles:feat: Feed 수정 기능 추가 및 모달 버그 해결

### DIFF
--- a/src/api/signUp.js
+++ b/src/api/signUp.js
@@ -25,7 +25,7 @@ export const signup = async (formData, data, profileImg) => {
     return res;
   } catch (err) {
     alert(err.response.data.message);
-    console.log(err.response.data.message);
+    console.error(err.response.data.message);
   }
 };
 

--- a/src/components/Error/StyledError.jsx
+++ b/src/components/Error/StyledError.jsx
@@ -5,15 +5,14 @@ const ErrorWrapper = styled.section`
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  gap: 20px;
+  gap: 24px;
   background-color: #fff;
 `;
 const ErrorImg = styled.img`
-  margin: -70px 0 -10px 0;
-  width: 150px;
+  margin: -70px 0 10px 0;
+  width: 103px;
 `;
 const ErrorText = styled.h2`
-  margin: 0px;
   font-weight: 400;
   font-size: 14px;
   color: #767676;

--- a/src/components/Feed/FeedComment/FeedComment.jsx
+++ b/src/components/Feed/FeedComment/FeedComment.jsx
@@ -21,7 +21,7 @@ import {
 import { useRecoilState } from 'recoil';
 import { modalState } from '../../../recoil/modalAtom';
 
-export default function DetailFeed() {
+export default function FeedComment() {
   const [inputValue, setInputValue] = useState('');
   // const [selectedId, setSelectedId] = useState(null);
   const [commentList, setCommentList] = useState([]);

--- a/src/components/Feed/FeedCreate/StyledFeedCreate.jsx
+++ b/src/components/Feed/FeedCreate/StyledFeedCreate.jsx
@@ -10,15 +10,21 @@ const StyledContainer = styled.section`
   background: #fff;
 `;
 
+const TextContainer = styled.form`
+  width: 100%;
+  display: flex;
+`;
+
 const StyledFeed = styled.textarea`
+  display: block;
   margin: 15px;
   padding: 15px;
-  width: 90%;
-  height: 50%;
+  width: 100%;
+  height: fit-content;
   box-sizing: border-box;
   border: 0.5px solid #c4c4c4;
   border-radius: 10px;
-  font-size: 15px;
+  font-size: 14px;
   font-family: 'SpoqaHanSansNeo-Regular', sans-serif;
   resize: none;
   &:focus {
@@ -55,9 +61,10 @@ const SocialSVG = ({ id, color = '#FFFFFF', size = 35, previews }) => (
 const H3 = styled.h3`
   width: 342px;
   font-family: 'SpoqaHanSansNeo-Regular', sans-serif;
-  font-size: 15px;
+  font-size: 12px;
+  font-weight: 500;
   color: #767676;
   margin: 0 auto 15px;
 `;
 
-export { StyledContainer, StyledFeed, SocialSVG, H3 };
+export { StyledContainer, StyledFeed, SocialSVG, H3, TextContainer };

--- a/src/components/Feed/FeedHome/FeedHome.jsx
+++ b/src/components/Feed/FeedHome/FeedHome.jsx
@@ -71,19 +71,33 @@ export default function FeedHome() {
     });
   };
 
-  const openYourProfile = (accountname) => {
-    navigate(`/profile/${accountname}`);
-  };
+  function moveProfile(accountname) {
+    const where = localStorage.getItem('accountname');
+    if (accountname === where) {
+      navigate('/myprofile', {
+        state: {
+          accountname: accountname,
+        },
+      });
+    } else {
+      navigate(`/profile/${accountname}`, {
+        state: {
+          accountname: accountname,
+        },
+      });
+    }
+    setModal((prevModal) => ({ ...prevModal, show: false }));
+  }
 
-  const moveDetail = (item) => {
-    navigate('/detailfeed', {
+  function moveDetail(item) {
+    navigate('/feeddetail', {
       state: {
         id: item.id,
         infoToIterate: item,
       },
     });
     setModal({ show: false });
-  };
+  }
 
   return (
     // eslint-disable-next-line react/jsx-no-useless-fragment
@@ -102,8 +116,7 @@ export default function FeedHome() {
                       item,
                     )
                   }
-                  feedInfo={where === item.author.accountname ? item : false}
-                  otherInfo={where === item.author.accountname ? false : item}
+                  feedInfo={item}
                   commentCnt={item.commentCount}
                   // getFeed={getFeed}
                   // skip={skip}
@@ -115,8 +128,8 @@ export default function FeedHome() {
           {modal.show && (
             <Modal
               type={modal.type}
-              handlerYourProfile={() => openYourProfile(modal.accountname)}
-              handlerDetailFeed={() => moveDetail(modal.item)}
+              handlerProfile={() => moveProfile(modal.accountname)}
+              handlerFeedDetail={() => moveDetail(modal.item)}
             />
           )}
         </main>

--- a/src/components/Feed/FeedItem/StyledFeedItem.jsx
+++ b/src/components/Feed/FeedItem/StyledFeedItem.jsx
@@ -3,7 +3,9 @@ import styled from 'styled-components';
 const Container = styled.article`
   position: relative;
   width: 100%;
-  margin-bottom: 20px;
+  padding: 10px;
+  border-radius: 10px;
+  box-sizing: border-box;
   &:hover {
     background-color: rgba(0, 0, 0, 0.05);
   }
@@ -39,7 +41,6 @@ const FeedContent = styled.div`
   font-size: 14px;
   line-height: 17px;
   word-break: break-all;
-  cursor: pointer;
 `;
 const FeedText = styled.p`
   margin-bottom: 17px;

--- a/src/components/Feed/FeedList/FeedList.jsx
+++ b/src/components/Feed/FeedList/FeedList.jsx
@@ -25,6 +25,7 @@ import {
 import { userFeedListApi } from '../../../api/feed';
 import { useRecoilState } from 'recoil';
 import { modalState } from '../../../recoil/modalAtom';
+import { feedState } from '../../../recoil/feedEditAtom';
 import { useRef } from 'react';
 import Loading from '../../Loading/Loading';
 
@@ -42,6 +43,7 @@ export default function FeedList() {
   const [hasFeeds, setHasFeeds] = useState(false);
   const [feedEditModalOpen, setFeedEditModalOpen] = useState(false);
   const [modal, setModal] = useRecoilState(modalState);
+  const [feed, setFeed] = useRecoilState(feedState);
   const observer = useRef();
   const [skip, setSkip] = useState(0);
   const [page, setPage] = useState(0);
@@ -86,7 +88,7 @@ export default function FeedList() {
   }, []);
 
   function moveDetail(item) {
-    navigate(`/feeddetail`, {
+    navigate('/feeddetail', {
       state: {
         id: item.id,
         infoToIterate: item,
@@ -95,10 +97,21 @@ export default function FeedList() {
     setModal({ show: false });
   }
 
+  function moveUpload(item) {
+    navigate('/feedUpload');
+    setModal({ show: false });
+    setFeed({
+      type: 'edit',
+      id: item.id,
+      images: item.image.split(','),
+      text: item.content,
+    });
+  }
+
   const modalOpen = (type, item) => {
     setModal({
       show: true,
-      type,
+      type: type,
       feedId: item.id,
       accountname: item.author.accountname,
       item: item,
@@ -236,7 +249,8 @@ export default function FeedList() {
         <Modal
           type={modal.type}
           handlerFeedEdit={openFeedEditModal}
-          handlerDetailFeed={() => moveDetail(modal.item)}
+          handlerFeedDetail={() => moveDetail(modal.item)}
+          handlerFeedEdit2={() => moveUpload(modal.item)}
         />
       )}
       {feedEditModalOpen && (

--- a/src/components/Feed/FeedList/StyledFeedList.jsx
+++ b/src/components/Feed/FeedList/StyledFeedList.jsx
@@ -29,7 +29,7 @@ const FeedItemList = styled.ul`
   flex-direction: column;
   align-items: center;
   background-color: white;
-  margin: 16px 20px 60px;
+  margin: 16px 10px 60px;
 
   &::-webkit-scrollbar {
     width: 10px;

--- a/src/components/Map/PlaceMap.jsx
+++ b/src/components/Map/PlaceMap.jsx
@@ -10,7 +10,7 @@ import {
   Close,
 } from './StyledPlaceMap';
 import { useLocation } from 'react-router-dom';
-import Modal from '../../components/Modal/Modal/Modal';
+import Modal from '../Modal/Modal/Modal';
 import { useRecoilState } from 'recoil';
 import { modalState } from '../../recoil/modalAtom';
 import './CssPlaceMap.css';

--- a/src/components/Modal/Modal/Modal.jsx
+++ b/src/components/Modal/Modal/Modal.jsx
@@ -16,13 +16,13 @@ export default function Modal({
   productId,
   placeName,
   placeLink,
-  handlerYourProfile,
-  handlerMyProfile,
+  handlerProfile,
   handlerFeedEdit,
+  handlerFeedEdit2,
   handlerCommentEdit,
   handlerPlaceEdit,
   handleCommentDelete,
-  handlerDetailFeed,
+  handlerFeedDetail,
   recommendInfo,
   detail,
 }) {
@@ -100,7 +100,6 @@ export default function Modal({
     });
     setModal((prevModal) => ({ ...prevModal, show: false }));
   }
-  //~수정중
   const UI = {
     yourProfile: (
       <ModalWrapArticle>
@@ -116,7 +115,7 @@ export default function Modal({
     myProfile: (
       <ModalWrapArticle>
         <ModalLineSpan />
-        <ModalTextBtn onClick={handlerMyProfile}>설정 및 개인정보</ModalTextBtn>
+        <ModalTextBtn>내 프로필 공유하기</ModalTextBtn>
         <ModalTextBtn onClick={() => alertOpen('logout')}>
           로그아웃
         </ModalTextBtn>
@@ -126,9 +125,9 @@ export default function Modal({
       <ModalWrapArticle>
         <ModalLineSpan />
         {detail || (
-          <ModalTextBtn onClick={handlerDetailFeed}>상세보기</ModalTextBtn>
+          <ModalTextBtn onClick={handlerFeedDetail}>상세보기</ModalTextBtn>
         )}
-        <ModalTextBtn onClick={handlerYourProfile}>이 계정 정보</ModalTextBtn>
+        <ModalTextBtn onClick={handlerProfile}>이 계정 정보</ModalTextBtn>
         <ModalTextBtn onClick={() => alertOpen('reportFeed')}>
           신고하기
         </ModalTextBtn>
@@ -137,15 +136,16 @@ export default function Modal({
     myFeed: (
       <ModalWrapArticle>
         <ModalLineSpan />
-        <ModalTextBtn onClick={handlerDetailFeed}>상세보기</ModalTextBtn>
+        <ModalTextBtn onClick={handlerFeedDetail}>상세보기</ModalTextBtn>
         <ModalTextBtn onClick={() => alertOpen('feed')}>삭제</ModalTextBtn>
-        <ModalTextBtn onClick={handlerFeedEdit}>수정</ModalTextBtn>
+        {/* <ModalTextBtn onClick={handlerFeedEdit}>수정</ModalTextBtn> */}
+        <ModalTextBtn onClick={handlerFeedEdit2}>수정</ModalTextBtn>
       </ModalWrapArticle>
     ),
     yourComment: (
       <ModalWrapArticle>
         <ModalLineSpan />
-        <ModalTextBtn onClick={handlerYourProfile}>이 계정 정보</ModalTextBtn>
+        <ModalTextBtn onClick={handlerProfile}>이 계정 정보</ModalTextBtn>
         <ModalTextBtn onClick={() => alertOpen('reportComment')}>
           신고하기
         </ModalTextBtn>

--- a/src/components/common/Header/Header.jsx
+++ b/src/components/common/Header/Header.jsx
@@ -16,11 +16,11 @@ import {
 import Button from '../Button/Button';
 import { useNavigate } from 'react-router-dom';
 import sprite from '../../../images/SpriteIcon.svg';
-import { useSetRecoilState } from 'recoil';
+import { useSetRecoilState, useRecoilState } from 'recoil';
 import { modalState } from '../../../recoil/modalAtom';
 import StarImg from '../../../images/Star.svg';
-import { useRecoilState } from 'recoil';
 import { viewBtnState } from '../../../recoil/viewBtnAtom';
+import { feedState } from '../../../recoil/feedEditAtom';
 
 export default function Header({
   type,
@@ -32,6 +32,7 @@ export default function Header({
   yourAccountname,
   name,
   own,
+  edit,
 }) {
   const SocialSVG = ({
     id,
@@ -52,6 +53,7 @@ export default function Header({
     setModal({ show: true, type: 'myProfile' });
   };
   const [viewMode, setViewMode] = useRecoilState(viewBtnState);
+  const setFeed = useSetRecoilState(feedState);
 
   function renderHeaderLeftBtn() {
     return (
@@ -64,7 +66,13 @@ export default function Header({
     return (
       <HeaderSpan>
         <HeaderLeftBtn type='button' aria-label='뒤로가기 버튼'>
-          <SocialSVG id='icon-arrow-left' onClick={() => navigate(-1)} />
+          <SocialSVG
+            id='icon-arrow-left'
+            onClick={() => {
+              edit && setFeed({ type: 'new', id: null, images: [], text: '' });
+              return navigate(-1);
+            }}
+          />
         </HeaderLeftBtn>
         <HeaderTextP title={text}>{text}</HeaderTextP>
       </HeaderSpan>
@@ -136,10 +144,12 @@ export default function Header({
       <HeaderLayoutSection>
         <HeaderTitle className='a11y-hidden'>게시물 작성</HeaderTitle>
         {/* {renderHeaderLeftBtn()} */}
-        {renderHeaderText('냠냠피드 작성')}
+        {edit
+          ? renderHeaderText('냠냠피드 수정')
+          : renderHeaderText('냠냠피드 작성')}
         <Button
           type='button'
-          content='업로드'
+          content={edit ? '수정하기' : '업로드'}
           size='ms'
           width='ms'
           $bgcolor={handleUploadBtn ? 'active' : 'inactive'}

--- a/src/pages/Profile/Profile.jsx
+++ b/src/pages/Profile/Profile.jsx
@@ -7,16 +7,10 @@ import RatePlace from '../../components/Profile/RatePlace';
 import PlaceCard from '../../components/Modal/PlaceCard/PlaceCard';
 import { useRecoilState } from 'recoil';
 import { cardShowState } from '../../recoil/cardShowAtom';
-import { modalState } from '../../recoil/modalAtom';
-import { Navigate } from 'react-router-dom';
-import Modal from '../../components/Modal/Modal/Modal';
 
 export default function Profile({ type }) {
   const [selectedId, setSelectedId] = useState(null);
   const [cardClosed, setCardClosed] = useState(false);
-  // eslint-disable-next-line no-unused-vars
-  const [modal, setModal] = useRecoilState(modalState);
-  const accountname = localStorage.getItem('accountname');
 
   const [cardShow, setCardShow] = useRecoilState(cardShowState);
   function cardClose(e) {
@@ -36,10 +30,6 @@ export default function Profile({ type }) {
     }
   }, [cardClosed]);
 
-  const moveProfileEdit = (accountname) => {
-    Navigate(`/profile/${accountname}`);
-  };
-
   return (
     <>
       <Header type='profile' own={type} />
@@ -48,12 +38,6 @@ export default function Profile({ type }) {
       <FeedList />
       {cardShow && selectedId && (
         <PlaceCard cardClose={cardClose} id={selectedId} />
-      )}
-      {modal.show && (
-        <Modal
-          type={modal.type}
-          handlerMyProfile={() => moveProfileEdit(accountname)}
-        />
       )}
       <Nav />
     </>

--- a/src/recoil/feedEditAtom.js
+++ b/src/recoil/feedEditAtom.js
@@ -1,0 +1,13 @@
+import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+const { persistAtom } = recoilPersist();
+
+// recoil의 저장소 상태의 기본 형태
+// key는 상태에 대한 식별자로 다른 상태 key 이름을 중복 선언하면 에러
+// 통상적으로 key 이름은 변수 이름하고 똑같이 함
+// default는 초기값
+export const feedState = atom({
+  key: 'feedState',
+  default: { type: 'new', id: null, images: [], text: '' },
+  effects_UNSTABLE: [persistAtom],
+});


### PR DESCRIPTION
## 💡 관련 이슈
- #31 
- #70 

## ✍️ PR 한 줄 요약
- Feed 수정 기능 추가 및 모달 버그 해결

## ✏ 상세 작업 내용
- [x] Feed Upload 페이지 및 관련 컴포넌트를 재사용하여 Feed 수정할 수 있는 기능 추가
- [x] Feed의 소유자일 경우 FeedItem 더보기 모달을 통해 작성된 내용을 기반으로 수정 가능
- [x] 신규 Feed 생성과 Feed 수정 시 버튼 및 API 사용을 분리함
- [x] Profile 페이지에서 FeedItem 모달 사용 불가 이슈 해결
- [x] Home 페이지에서 Feed 상세 페이지 이동 불가 모달 기능 이슈 해결
- [x] Home 페이지에서 Profile로 이동 시 데이터 미전달 이슈 해결 
- [x] Home 페이지에서 FeedItem 더보기를 통해 상세 페이지 이동 불가 이슈 해결

## ⭐ 참고 사항

## ✅ PR 양식 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. ✨feat: PR 등록
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
