### PR TITLE
:sparkles:feat: 타사용자에서 바로 프로필 넘어가면 해당 데이터 불러오도록 변경

### DIFF
--- a/src/components/Feed/FeedList/FeedList.jsx
+++ b/src/components/Feed/FeedList/FeedList.jsx
@@ -136,7 +136,7 @@ export default function FeedList() {
     setSkip(0);
     setPage(0);
     setFeedInfo([]);
-  }, []);
+  }, [location.state]);
 
   return (
     <>


### PR DESCRIPTION
## 💡 관련 이슈

- #29

## ✍️ PR 한 줄 요약

타사용자에서 바로 프로필 넘어가면 새로 데이터 불러오도록 변경

## ✏ 상세 작업 내용

타사용자에서 바로 프로필 넘어가면 타사용자의 게시글이 유지가 되었다.

저번에 프로필 관련 오류 해결하면서 location을 없앴는데 location을 없앨게 아니라 location.state로 변경해줬어야했다.

## ⭐ 참고 사항

## ✅ PR 양식 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. ✨feat: PR 등록
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
