### PR TITLE
:bug:fix: FeedDetail의 모달 상세보기 안나오도록 수정

### DIFF
--- a/src/components/Modal/Modal/Modal.jsx
+++ b/src/components/Modal/Modal/Modal.jsx
@@ -146,7 +146,9 @@ export default function Modal({
     myFeed: (
       <ModalWrapArticle>
         <ModalLineSpan />
-        <ModalTextBtn onClick={handlerFeedDetail}>상세보기</ModalTextBtn>
+        {detail || (
+          <ModalTextBtn onClick={handlerFeedDetail}>상세보기</ModalTextBtn>
+        )}
         <ModalTextBtn onClick={() => alertOpen('feed')}>삭제</ModalTextBtn>
         <ModalTextBtn onClick={handlerFeedEdit}>수정</ModalTextBtn>
       </ModalWrapArticle>


### PR DESCRIPTION
## 💡 관련 이슈
- #37

## ✍️ PR 한 줄 요약
- FeedDetail의 모달 상세보기 안나오도록 수정
- modal.jsx 파일 수정

## ✏ 상세 작업 내용


## ⭐ 참고 사항

## ✅ PR 양식 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. ✨feat: PR 등록
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
