### PR TITLE
:bug:fix: 채팅방 데이터 넘김 오류 해결

### DIFF
--- a/src/components/Chat/ChatListItem.jsx
+++ b/src/components/Chat/ChatListItem.jsx
@@ -57,7 +57,7 @@ export default function ChatListItem() {
       dot: false,
     },
   ];
-  const [chat, setChat] = useRecoilState(chatState);
+  const [, setChat] = useRecoilState(chatState);
   const navigate = useNavigate();
 
   return (

--- a/src/components/Profile/BtnProfile.jsx
+++ b/src/components/Profile/BtnProfile.jsx
@@ -10,8 +10,11 @@ import {
 } from './StyledBtnProfile';
 import sprite from '../../images/SpriteIcon.svg';
 import { followApi, unfollowApi } from '../../api/follow';
+import { useRecoilState } from 'recoil';
+import { chatState } from '../../recoil/chatAtom';
 
 export default function BtnProfile({ type, id, setFollow, follow }) {
+  const [, setChat] = useRecoilState(chatState);
   const SocialSVG = ({ id, color = 'white', size = 20 }) => (
     <svg fill={color} width={size} height={size}>
       <use href={`${sprite}#${id}`} />
@@ -32,8 +35,18 @@ export default function BtnProfile({ type, id, setFollow, follow }) {
   function moveChat(id) {
     navigate(`/chatroom/${id}`, {
       state: {
-        yourAccountname: id,
+        accountname: id,
       },
+    });
+    setChat({
+      type: 'new',
+      id: null,
+      name: '',
+      image: [],
+      text: [],
+      time: '',
+      date: [],
+      reply: false,
     });
   }
 

--- a/src/components/common/Header/Header.jsx
+++ b/src/components/common/Header/Header.jsx
@@ -63,6 +63,7 @@ export default function Header({
       userName = '나의 게시글';
     }
   }
+
   const navigate = useNavigate();
   const setModal = useSetRecoilState(modalState);
   const modalOpen = () => {
@@ -148,7 +149,7 @@ export default function Header({
         <HeaderTitle className='a11y-hidden'>프로필</HeaderTitle>
         {own === 'my'
           ? renderHeaderText('나의 프로필')
-          : renderHeaderText(`${userName}`)}
+          : renderHeaderText(`@ ${userName}`)}
         {renderHeaderRightBtn()}
       </HeaderLayoutSection>
     ),
@@ -199,9 +200,11 @@ export default function Header({
     chat: (
       <HeaderLayoutSection>
         <HeaderTitle className='a11y-hidden'>채팅</HeaderTitle>
-        {name
+        {yourAccountname === undefined
           ? renderHeaderText('채팅')
-          : renderHeaderText(`@ ${yourAccountname}`)}
+          : yourAccountname
+          ? renderHeaderText(`@ ${yourAccountname}`)
+          : renderHeaderText(`@ ${accountname}`)}
         {renderHeaderRightBtn()}
       </HeaderLayoutSection>
     ),


### PR DESCRIPTION
## 💡 관련 이슈
- #98 

## ✍️ PR 한 줄 요약

채팅방 데이터 넘김 오류 해결

## ✏ 상세 작업 내용

1. 프로필에서 채팅방 넘어가면 헤더 null 해결
2. 채팅방에서 데이터 불러오고 프로필 채팅버튼 누르면 기존 데이터 유지현상 해결
3. 채팅방 헤더 조건 추가

## ⭐ 참고 사항

## ✅ PR 양식 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. ✨feat: PR 등록
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
