### PR TITLE
:recycle:refactor: 브라우저 종료시 스토리지 삭제

### DIFF
--- a/src/components/Comment/Comment.jsx
+++ b/src/components/Comment/Comment.jsx
@@ -13,7 +13,7 @@ import {
 import { useRecoilState } from 'recoil';
 import { modalState } from '../../recoil/modalAtom';
 export default function Comment({ commentList, feedId }) {
-  const where = localStorage.getItem('accountname');
+  const where = sessionStorage.getItem('accountname');
   const navigate = useNavigate();
 
   const SocialSVG = ({

--- a/src/components/Feed/FeedComment/FeedComment.jsx
+++ b/src/components/Feed/FeedComment/FeedComment.jsx
@@ -28,8 +28,8 @@ export default function FeedComment() {
   const location = useLocation();
   const [comment, setComment] = useState([]);
   const data = location.state;
-  const token = localStorage.getItem('token');
-  const where = localStorage.getItem('accountname');
+  const token = sessionStorage.getItem('token');
+  const where = sessionStorage.getItem('accountname');
   const { id, infoToIterate } = data;
   const [commentCnt, setCommentCnt] = useState(infoToIterate.commentCount);
   const [myFeedInfo, setMyFeedInfo] = useState(infoToIterate);

--- a/src/components/Feed/FeedCreate/FeedCreate.jsx
+++ b/src/components/Feed/FeedCreate/FeedCreate.jsx
@@ -34,8 +34,8 @@ export default function FeedCreate() {
   const [content, setContent] = useState(feed.type === 'edit' ? feed.text : '');
   // const [imgUrl, setImgUrl] = useState(feed.type === 'edit' ? feed.images : []);
   const [imgFile, setImgFile] = useState([]);
-  const token = localStorage.getItem('token');
-  const username = localStorage.getItem('accountname');
+  const token = sessionStorage.getItem('token');
+  const username = sessionStorage.getItem('accountname');
   const dragItem = useRef(); // 드래그할 아이템의 인덱스
   const dragOverItem = useRef();
   const fileInputRef = useRef(null);

--- a/src/components/Feed/FeedHome/FeedHome.jsx
+++ b/src/components/Feed/FeedHome/FeedHome.jsx
@@ -22,8 +22,8 @@ export default function FeedHome() {
   const [page, setPage] = useState(0);
   const observer = useRef();
   const navigate = useNavigate();
-  const token = localStorage.getItem('token');
-  const where = localStorage.getItem('accountname');
+  const token = sessionStorage.getItem('token');
+  const where = sessionStorage.getItem('accountname');
 
   const getFeed = async (options) => {
     const res = await feed(options);
@@ -72,7 +72,7 @@ export default function FeedHome() {
   };
 
   function moveProfile(accountname) {
-    const where = localStorage.getItem('accountname');
+    const where = sessionStorage.getItem('accountname');
     if (accountname === where) {
       navigate('/myprofile', {
         state: {

--- a/src/components/Feed/FeedItem/FeedItem.jsx
+++ b/src/components/Feed/FeedItem/FeedItem.jsx
@@ -52,7 +52,7 @@ export default function FeedItem({
   const [heartCnt, setHeartCnt] = useState(infoToIterate.heartCount);
 
   const feedLike = async () => {
-    const token = localStorage.getItem('token');
+    const token = sessionStorage.getItem('token');
     try {
       if (isHearted) {
         await feedUnlikeApi(infoToIterate.id, token);
@@ -81,7 +81,7 @@ export default function FeedItem({
   }
 
   function moveProfile(accountname) {
-    const where = localStorage.getItem('accountname');
+    const where = sessionStorage.getItem('accountname');
     if (accountname === where) {
       navigate('/myprofile', {
         state: {

--- a/src/components/Feed/FeedList/FeedList.jsx
+++ b/src/components/Feed/FeedList/FeedList.jsx
@@ -47,7 +47,7 @@ export default function FeedList() {
   const [page, setPage] = useState(0);
   const limit = 10;
   const [loading, setLoading] = useState(true);
-  const where = localStorage.getItem('accountname');
+  const where = sessionStorage.getItem('accountname');
 
   const { accountname } = location.state || {};
   const handleViewModeChange = (mode) => {
@@ -55,11 +55,11 @@ export default function FeedList() {
   };
 
   const getUserInfo = useCallback(async () => {
-    const token = localStorage.getItem('token');
+    const token = sessionStorage.getItem('token');
     setLoading(true);
     try {
       const res = await userFeedListApi(
-        accountname || localStorage.getItem('accountname'),
+        accountname || sessionStorage.getItem('accountname'),
         token,
         limit,
         skip,

--- a/src/components/FollowItem/FollowItem.jsx
+++ b/src/components/FollowItem/FollowItem.jsx
@@ -18,8 +18,8 @@ export default function FollowItem({
   isfollow,
 }) {
   const [follow, setFollow] = useState(isfollow);
-  const myaccountname = localStorage.getItem('accountname');
-  const token = localStorage.getItem('token');
+  const myaccountname = sessionStorage.getItem('accountname');
+  const token = sessionStorage.getItem('token');
   const navigate = useNavigate();
 
   function moveProfile(accountname) {

--- a/src/components/Login/LoginForm.jsx
+++ b/src/components/Login/LoginForm.jsx
@@ -25,9 +25,9 @@ export default function LoginForm() {
       const accountname = loginData.data.user.accountname;
       const _id = loginData.data.user._id;
 
-      localStorage.setItem('token', token);
-      localStorage.setItem('_id', _id);
-      localStorage.setItem('accountname', accountname);
+      sessionStorage.setItem('token', token);
+      sessionStorage.setItem('_id', _id);
+      sessionStorage.setItem('accountname', accountname);
 
       setLoginSuccess(true);
     } catch (err) {

--- a/src/components/Modal/Alert/Alert.jsx
+++ b/src/components/Modal/Alert/Alert.jsx
@@ -29,22 +29,22 @@ export default function Alert({
   const [modal, setModal] = useRecoilState(modalState);
   const setCardShow = useSetRecoilState(cardShowState);
   const onClickLogout = () => {
-    localStorage.removeItem('token');
-    localStorage.removeItem('accountname');
-    localStorage.removeItem('_id');
-    localStorage.removeItem('follow');
+    sessionStorage.removeItem('token');
+    sessionStorage.removeItem('accountname');
+    sessionStorage.removeItem('_id');
+    sessionStorage.removeItem('follow');
     navigate('/welcome');
     setModal((prevModal) => ({ ...prevModal, show: false }));
   };
   const handleDeleteFeed = async () => {
-    const token = localStorage.getItem('token');
+    const token = sessionStorage.getItem('token');
     try {
       await feedDeleteApi(modal.feedId, token);
       alertClose('feed');
       modalClose('myFeed');
       navigate('/myprofile', {
         state: {
-          accountname: localStorage.getItem('accountname'),
+          accountname: sessionStorage.getItem('accountname'),
         },
       });
       try {
@@ -60,7 +60,7 @@ export default function Alert({
   };
 
   const handleDeletePlace = async () => {
-    const token = localStorage.getItem('token');
+    const token = sessionStorage.getItem('token');
     try {
       await recommendDeleteApi(productId, token);
       alertClose('place');
@@ -79,7 +79,7 @@ export default function Alert({
   };
 
   const handleDeleteComment = async () => {
-    const token = localStorage.getItem('token');
+    const token = sessionStorage.getItem('token');
     try {
       await commentDeleteApi(modal.feedId, modal.commentId, token);
       alertClose('comment');
@@ -91,7 +91,7 @@ export default function Alert({
   };
 
   const handleReportComment = async () => {
-    const token = localStorage.getItem('token');
+    const token = sessionStorage.getItem('token');
     try {
       await commentReportApi(modal.feedId, modal.commentId, token);
       alertClose('reportComment');
@@ -103,7 +103,7 @@ export default function Alert({
   };
 
   const handleReportFeed = async () => {
-    const token = localStorage.getItem('token');
+    const token = sessionStorage.getItem('token');
     try {
       await feedReportApi(modal.feedId, token);
       alertClose('reportFeed');

--- a/src/components/Modal/PlaceCard/PlaceCard.jsx
+++ b/src/components/Modal/PlaceCard/PlaceCard.jsx
@@ -31,7 +31,7 @@ export default function PlaceCard({ cardClose, id }) {
   let { accountname } = location.state || {};
 
   if (location.pathname === '/placelist') {
-    if (accountname === localStorage.getItem('accountname')) {
+    if (accountname === sessionStorage.getItem('accountname')) {
       accountname = '';
     }
   }
@@ -52,7 +52,7 @@ export default function PlaceCard({ cardClose, id }) {
   };
 
   const getUserInfo = async () => {
-    const token = localStorage.getItem('token');
+    const token = sessionStorage.getItem('token');
     try {
       await getPlaceInfoApi(id, token).then((res) => {
         const { itemImage, itemName, link, price } = res.data.product;

--- a/src/components/Place/PlaceListItem.jsx
+++ b/src/components/Place/PlaceListItem.jsx
@@ -24,11 +24,11 @@ export default function PlaceListItem({ cardOpen, cardClose, cardClosed }) {
   useEffect(() => {
     const getUserInfo = async () => {
       const { accountname } = location.state || {};
-      const token = localStorage.getItem('token');
+      const token = sessionStorage.getItem('token');
 
       try {
         const res = await placeListApi(
-          accountname || localStorage.getItem('accountname'),
+          accountname || sessionStorage.getItem('accountname'),
           token,
         );
         setPlaceInfo(res.data.product);

--- a/src/components/Profile/BtnProfile.jsx
+++ b/src/components/Profile/BtnProfile.jsx
@@ -24,7 +24,7 @@ export default function BtnProfile({ type, id, setFollow, follow }) {
   );
 
   const navigate = useNavigate();
-  const token = localStorage.getItem('token');
+  const token = sessionStorage.getItem('token');
 
   function moveProfileEdit() {
     navigate('/myprofile/edit');

--- a/src/components/Profile/InfoProfile.jsx
+++ b/src/components/Profile/InfoProfile.jsx
@@ -28,8 +28,8 @@ export default function InfoProfile({ type }) {
   const [followerInfo, setFollowerInfo] = useState([]);
   const [loading, setLoading] = useState(true);
   const location = useLocation();
-  const token = localStorage.getItem('token');
-  const myId = localStorage.getItem('_id');
+  const token = sessionStorage.getItem('token');
+  const myId = sessionStorage.getItem('_id');
 
   useEffect(() => {
     const getUserInfo = async () => {
@@ -99,11 +99,11 @@ export default function InfoProfile({ type }) {
   useEffect(() => {
     const following = followerInfo.some((x) => x === myId);
     setFollow(!following);
-    localStorage.setItem('follow', !following ? 'false' : 'true');
+    sessionStorage.setItem('follow', !following ? 'false' : 'true');
   }, [followerInfo, myId]);
 
   useEffect(() => {
-    const savedFollow = localStorage.getItem('follow');
+    const savedFollow = sessionStorage.getItem('follow');
     setFollow(savedFollow === 'false');
   }, []);
 

--- a/src/components/Profile/RatePlace.jsx
+++ b/src/components/Profile/RatePlace.jsx
@@ -32,10 +32,10 @@ export default function RatePlace({ cardOpen, cardClosed }) {
   useEffect(() => {
     setViewMode('별점순');
     const getUserInfo = async () => {
-      const token = localStorage.getItem('token');
+      const token = sessionStorage.getItem('token');
       try {
         const res = await placeListApi(
-          accountname || localStorage.getItem('accountname'),
+          accountname || sessionStorage.getItem('accountname'),
           token,
         );
         if (res.data.product.length > 0) {

--- a/src/components/ProfileEdit/ProfileEditForm.jsx
+++ b/src/components/ProfileEdit/ProfileEditForm.jsx
@@ -30,7 +30,7 @@ const ProfileEditForm = ({ userInfo, setUserInfo }) => {
 
   const [error, setErrors] = useState({});
   const [hasError, setHasError] = useState(false);
-  const token = localStorage.getItem('token');
+  const token = sessionStorage.getItem('token');
   const [profileImg, setProfileImg] = useState(null);
   const [abledBtn, setAbledBtn] = useState(true);
   const inputRef = useRef(null);
@@ -84,8 +84,8 @@ const ProfileEditForm = ({ userInfo, setUserInfo }) => {
       setProfileImg(userInfo?.image || DefaultProfileInput);
       const image = profileImg || userInfo?.image || DefaultProfileInput;
       const res = await profileEdit(formData, image, token);
-      localStorage.setItem('_id', res.data.user._id);
-      localStorage.setItem('accountname', formData.accountname);
+      sessionStorage.setItem('_id', res.data.user._id);
+      sessionStorage.setItem('accountname', formData.accountname);
       navigate('/myprofile');
     } catch (errors) {
       console.error(errors);

--- a/src/components/Search/SearchList.jsx
+++ b/src/components/Search/SearchList.jsx
@@ -15,7 +15,7 @@ export default function SearchList({ searchKeyword }) {
   const navigate = useNavigate();
 
   function handleClick(accountname) {
-    const where = localStorage.getItem('accountname');
+    const where = sessionStorage.getItem('accountname');
     if (accountname === where) {
       navigate('/myprofile', {
         state: {
@@ -54,7 +54,7 @@ export default function SearchList({ searchKeyword }) {
       return;
     } else {
       try {
-        const token = localStorage.getItem('token');
+        const token = sessionStorage.getItem('token');
         const res = await userSearch(keyword, token);
         const filteredData = res.data.filter(
           (item) =>

--- a/src/components/common/Header/Header.jsx
+++ b/src/components/common/Header/Header.jsx
@@ -59,7 +59,7 @@ export default function Header({
     location.state.infoToIterate.author.accountname
   ) {
     userName = location.state.infoToIterate.author.accountname;
-    if (userName === localStorage.accountname) {
+    if (userName === sessionStorage.accountname) {
       userName = '나의 게시글';
     }
   }

--- a/src/pages/FollowerList/FollowerList.jsx
+++ b/src/pages/FollowerList/FollowerList.jsx
@@ -14,7 +14,7 @@ import { followerListApi, followingListApi } from '../../api/follow';
 import FeedlistImg from '../../images/feedList-logo.svg';
 
 export default function FollowerList({ type, followType }) {
-  const token = localStorage.getItem('token');
+  const token = sessionStorage.getItem('token');
   const location = useLocation();
   const navigate = useNavigate();
   const accountname = location.state.accountname;

--- a/src/pages/Place/EditPlace.jsx
+++ b/src/pages/Place/EditPlace.jsx
@@ -22,7 +22,7 @@ export default function EditPlace() {
   const [place, setPlace] = useRecoilState(placeState);
   const [imgFile, setImgFile] = useState(null);
   const [imgUrl, setImgUrl] = useState(place ? place.itemImage || '' : '');
-  const token = localStorage.getItem('token');
+  const token = sessionStorage.getItem('token');
   const [isValid, setIsValid] = useState(false);
   const [addressList, setAddressList] = useState([]);
   const navigate = useNavigate();

--- a/src/pages/Place/MakePlace.jsx
+++ b/src/pages/Place/MakePlace.jsx
@@ -19,7 +19,7 @@ export default function MakePlace() {
   const [imgFile, setImgFile] = useState(null);
   const [imgUrl, setImgUrl] = useState('');
   const [restaurantname, setRestaurantname] = useState('');
-  const token = localStorage.getItem('token');
+  const token = sessionStorage.getItem('token');
   const [rating, setRating] = useState(0);
   const [isValid, setIsValid] = useState(false);
   const [addressList, setAddressList] = useState([]);

--- a/src/pages/Place/PlaceList.jsx
+++ b/src/pages/Place/PlaceList.jsx
@@ -32,9 +32,9 @@ export default function PlaceList() {
   useEffect(() => {
     if (nickname) {
       setName(nickname);
-      localStorage.setItem('nickname', nickname.name);
+      sessionStorage.setItem('nickname', nickname.name);
     } else {
-      setName(localStorage.getItem('nickname'));
+      setName(sessionStorage.getItem('nickname'));
     }
   }, [nickname]);
 

--- a/src/pages/Profile/ProfileEdit.jsx
+++ b/src/pages/Profile/ProfileEdit.jsx
@@ -4,7 +4,7 @@ import { userInfoApi } from '../../api/user';
 import ProfileEditForm from '../../components/ProfileEdit/ProfileEditForm';
 
 export default function ProfileEdit() {
-  const token = localStorage.getItem('token');
+  const token = sessionStorage.getItem('token');
   const navigate = useNavigate();
   const [userInfo, setUserInfo] = useState({
     image: '',

--- a/src/pages/Splash/Splash.jsx
+++ b/src/pages/Splash/Splash.jsx
@@ -6,7 +6,7 @@ import { Appear, LogoBowl, LogoName } from './SplashStyle';
 
 export default function Splash() {
   const navigate = useNavigate();
-  const token = localStorage.getItem('token');
+  const token = sessionStorage.getItem('token');
 
   useEffect(() => {
     if (token) {


### PR DESCRIPTION
## 💡 관련 이슈

- #103 

## ✍️ PR 한 줄 요약

브라우저 종료시 스토리지 삭제

## ✏ 상세 작업 내용

기존 localStorage에 값을 담았으나 이는 브라우저를 종료해도 데이터가 남게된다.
sessionStorage로 변경함으로써 페이지가 유지되는 동안만 존재하도록 변경

## ⭐ 참고 사항

## ✅ PR 양식 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. ✨feat: PR 등록
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
