### PR TITLE
:bug:lipstick:fix: feedDetail 댓글 개시 버튼 컬러 및 프로필 수정 뒤 모달 닫히도록 수정

### DIFF
--- a/src/components/Feed/FeedComment/StyledFeedComment.jsx
+++ b/src/components/Feed/FeedComment/StyledFeedComment.jsx
@@ -34,7 +34,7 @@ const WriteComment = styled.input`
 `;
 
 const BtnDisplay = styled.button`
-  color: ${({ $hastext }) => ($hastext ? '#286140' : '#C4C4C4')};
+  color: ${({ $hastext }) => ($hastext ? '#F26E22' : '#C4C4C4')};
 `;
 
 const FeedUserImg = styled.img`

--- a/src/components/Modal/Modal/Modal.jsx
+++ b/src/components/Modal/Modal/Modal.jsx
@@ -62,6 +62,7 @@ export default function Modal({
 
   function moveProfileEdit() {
     navigate('/myprofile/edit');
+    setModal((prevModal) => ({ ...prevModal, show: false }));
   }
 
   function kakaoButton(placeInfo) {

--- a/src/pages/Feed/FeedDetail.jsx
+++ b/src/pages/Feed/FeedDetail.jsx
@@ -5,7 +5,6 @@ import FeedComment from '../../components/Feed/FeedComment/FeedComment';
 
 export default function FeedDetail() {
   const location = useLocation();
-  window.console.log(location.state.infoToIterate.author.accountname);
   const accountname = location.state.infoToIterate.author.accountname;
   const where = localStorage.getItem('accountname');
   let own = where === accountname ? 'my' : 'other';


### PR DESCRIPTION
## 💡 관련 이슈
- #14 
- #37 

## ✍️ PR 한 줄 요약
- feedDetail 댓글 개시 버튼 컬러 및 프로필 수정 뒤 모달 닫히도록 수정

## ✏ 상세 작업 내용
- 게시 버튼 색상 변경 (F26E22)
- 헤더 더보기 모달에서 프로필 수정하기로 이동 후 모달이 닫히도록 수정
![image](https://github.com/FRONTENDSCHOOL7/final-12-HoloNyamNyam/assets/11751089/b1b6d1bd-0290-428e-a8c5-2a7f1b0fe539)

## ⭐ 참고 사항

## ✅ PR 양식 체크리스트

- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. ✨feat: PR 등록
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?
