### PR TITLE
:bug:fix: 프로필에서 제일 하단 게시글 삭제하면 게시글 날라감 현상 해결

### DIFF
--- a/src/components/Feed/FeedList/FeedList.jsx
+++ b/src/components/Feed/FeedList/FeedList.jsx
@@ -54,38 +54,38 @@ export default function FeedList({ feedRef }) {
     setViewMode(mode);
   };
 
+  const initialRender = useRef(true);
+
   const getUserInfo = useCallback(async () => {
-    const token = sessionStorage.getItem('token');
-    setLoading(true);
-    try {
-      const res = await userFeedListApi(
-        accountname || sessionStorage.getItem('accountname'),
-        token,
-        limit,
-        skip,
-      );
-      const posts = res.data.post;
-      // console.log(posts);
-      if (posts.length > 0) {
-        setHasFeeds(true);
-        setFeedInfo((prev) => [...prev, ...posts]);
-        // console.log(feedInfo);
+    if (initialRender.current) {
+      initialRender.current = false;
+    } else {
+      const token = sessionStorage.getItem('token');
+      setLoading(true);
+      try {
+        const res = await userFeedListApi(
+          accountname || sessionStorage.getItem('accountname'),
+          token,
+          limit,
+          skip,
+        );
+        const posts = res.data.post;
+        if (posts.length > 0) {
+          setHasFeeds(true);
+          setFeedInfo((prev) => [...prev, ...posts]);
+        }
+        setSkip((prev) => prev + posts.length);
+        setLoading(false);
+      } catch (error) {
+        console.error('error');
+        navigate('/error');
       }
-      setSkip((prev) => prev + posts.length);
-      setLoading(false);
-    } catch (error) {
-      console.error('error');
-      navigate('/error');
     }
   }, [accountname, limit, skip, navigate]);
 
   useEffect(() => {
-    if (page === 1) getUserInfo();
+    if (page === 0) getUserInfo();
   }, [page, getUserInfo]);
-
-  useEffect(() => {
-    setPage(1);
-  }, []);
 
   function moveDetail(item) {
     navigate('/feeddetail', {


### PR DESCRIPTION
## 💡 관련 이슈

- #115 

## ✍️ PR 한 줄 요약

프로필에서 제일 하단 게시글 삭제하면 게시글 날라감 현상 해결

## ✏ 상세 작업 내용

엄격모드때문제 게시글이 두번 나오는 현상을 방지하기 위해 페이지 조건을 1을 줬었다. 그러나 제일 하단 게시글을 삭제하면 통째로 데이터가 날라감
따라서 페이지 조건은 0으로 다시 수정하고 첫 렌더링인지 아닌지 판단하여 한번만 불러오도록 수정

## ⭐ 참고 사항

## ✅ PR 양식 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. ✨feat: PR 등록
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
