### PR TITLE
:lipstick:style: 게시물 작성 Nav를 누를 시 반짝임(새로고침) 최소화

### DIFF
--- a/src/components/common/Nav/Nav.jsx
+++ b/src/components/common/Nav/Nav.jsx
@@ -49,7 +49,7 @@ export default function Nav() {
 
   function newFeed() {
     setFeed({ type: 'new', id: null, images: [], text: '' });
-    window.location.reload();
+    if (location.pathname === '/feedupload') window.location.reload();
   }
 
   return (


### PR DESCRIPTION
## 💡 관련 이슈
- #1 
<!-- - #이슈번호 -->

## ✍️ PR 한 줄 요약
- Nav 게시물 작성 버튼을 누를 시 반짝이는 이슈 해결

## ✏ 상세 작업 내용
- 현재 페이지가 '/feedupload' 일 경우에만 window.location.reload 되도록 수정
- 즉, 새로고침 최소화

## ⭐ 참고 사항

## ✅ PR 양식 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. ✨feat: PR 등록
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
