### PR TITLE
:recycle:refactor: 프로필 사진 엑박 해결과 디폴트 이미지 넣기

### DIFF
--- a/src/components/ProfileEdit/ProfileEditForm.jsx
+++ b/src/components/ProfileEdit/ProfileEditForm.jsx
@@ -75,7 +75,10 @@ const ProfileEditForm = ({ userInfo, setUserInfo }) => {
     const file = event.target.files[0];
     formData.append('image', file);
     await imgUpload(formData).then((res) => {
-      const imgUrl = `${BASE_URL}/` + res.data.filename;
+      let imgUrl = `${BASE_URL}/` + res.data.filename;
+      if (imgUrl === `${BASE_URL}/` + undefined) {
+        imgUrl = DefaultProfileInput;
+      }
       setProfileImg(imgUrl);
       setImageChanged(true);
     });

--- a/src/components/ProfileSetting/ProfileSettingForm.jsx
+++ b/src/components/ProfileSetting/ProfileSettingForm.jsx
@@ -75,7 +75,10 @@ const ProfileSettingForm = () => {
     const file = event.target.files[0];
     formData.append('image', file);
     await imgUpload(formData).then((res) => {
-      const imgUrl = `${BASE_URL}/` + res.data.filename;
+      let imgUrl = `${BASE_URL}/` + res.data.filename;
+      if (imgUrl === `${BASE_URL}/` + undefined) {
+        imgUrl = DefaultProfileInput;
+      }
       setProfileImg(imgUrl);
     });
   };
@@ -83,8 +86,12 @@ const ProfileSettingForm = () => {
   const handleSubmitData = async (formData) => {
     try {
       const isValidUserId = await checkUserIdValid(formData.accountname);
+      let defaultImg = profileImg;
+      if (defaultImg === null) {
+        defaultImg = DefaultProfileInput;
+      }
       if (isValidUserId) {
-        await signup(formData, data, profileImg).then(
+        await signup(formData, data, defaultImg).then(
           navigate('/signup/signupsuccess'),
         );
       }


### PR DESCRIPTION
## 💡 관련 이슈

- #137 

## ✍️ PR 한 줄 요약

프로필 사진 엑박 해결과 디폴트 이미지 넣기

## ✏ 상세 작업 내용

onchange 이벤트를 통해서 이미지가 변경되고 값이 들어가므로
폼제출할때 null값을 판단하여 디폴트이미지 넣어줌

또 onchange가 발생했을때도 파일을 잃어버리면 디폴트 이미지가 들어가도록 코드 주가

## ⭐ 참고 사항

## ✅ PR 양식 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. ✨feat: PR 등록
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
