### PR TITLE
:bug:fix: 게시물 상세보기에서 모달 상세보기가 나오는 이슈

### DIFF
--- a/src/components/Modal/Modal/Modal.jsx
+++ b/src/components/Modal/Modal/Modal.jsx
@@ -187,7 +187,9 @@ export default function Modal({
     myFeed: (
       <ModalWrapArticle>
         <ModalLineSpan />
-        <ModalTextBtn onClick={handlerFeedDetail}>상세보기</ModalTextBtn>
+        {detail || (
+          <ModalTextBtn onClick={handlerFeedDetail}>상세보기</ModalTextBtn>
+        )}
         <ModalTextBtn onClick={() => alertOpen('feed')}>삭제</ModalTextBtn>
         <ModalTextBtn onClick={handlerFeedEdit}>수정</ModalTextBtn>
       </ModalWrapArticle>

--- a/src/components/Signup/SignUpForm.jsx
+++ b/src/components/Signup/SignUpForm.jsx
@@ -3,7 +3,7 @@ import Input from '../../components/common/Input/Input';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { EmailValid } from '../../api/signUp';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { signUpState } from '../../recoil/signUpAtom';
 import {
   StyledSignUpWrap,
@@ -26,7 +26,7 @@ const SignUpForm = () => {
   const navigate = useNavigate();
   const [hasError, setHasError] = useState(false);
   const [error, setErrors] = useState({});
-  const [signUp, setSignUp] = useRecoilState(signUpState);
+  const setSignUp = useSetRecoilState(signUpState);
 
   const checkEmailValid = async (email) => {
     try {


### PR DESCRIPTION
## 💡 관련 이슈
- #55 
<!-- - #이슈번호 -->

## ✍️ PR 한 줄 요약
- 게시물 상세보기에서 모달 상세보기가 나오는 이슈

## ✏ 상세 작업 내용
- modal이 게시물 상세보기일 경우 모달에서 상세보기 안나오도록 처리

## ⭐ 참고 사항

## ✅ PR 양식 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. ✨feat: PR 등록
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
